### PR TITLE
마이 페이지 추가 

### DIFF
--- a/src/api/post/postList.js
+++ b/src/api/post/postList.js
@@ -1,5 +1,5 @@
-export async function getPosts() {
-  const response = await fetch('/api/post?type=ALL&skip=0&take=12', {
+export async function getPosts(type) {
+  const response = await fetch(`/api/post?type=${type}&skip=0&take=12`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/src/api/user/getUser.js
+++ b/src/api/user/getUser.js
@@ -1,0 +1,12 @@
+export async function getUser() {
+  const response = await fetch(`/api/user`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error('Failed to fetch posts');
+  }
+  return response.json();
+}

--- a/src/component/CardList.jsx
+++ b/src/component/CardList.jsx
@@ -21,8 +21,8 @@ export default function CardList() {
       box-border
     "
     >
-      {posts.map((post, i) => (
-        <Card key={i} post={post} />
+      {posts.map((post) => (
+        <Card key={post.uuid} post={post} />
       ))}
     </div>
   );

--- a/src/component/CardList.jsx
+++ b/src/component/CardList.jsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react';
 import Card from './Card';
 import { getPosts } from '../api/post/postList.js';
 
-export default function CardList() {
+export default function CardList({ type }) {
   const [posts, setPosts] = useState([]);
 
   useEffect(() => {
-    getPosts().then((data) => {
+    getPosts(type).then((data) => {
       setPosts(data.posts);
     });
-  }, []);
+  }, [type]);
 
   return (
     <div

--- a/src/component/Sidebar.jsx
+++ b/src/component/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { useRouter } from '@tanstack/react-router';
+import { Link, useRouter } from '@tanstack/react-router';
 
 export default function Sidebar() {
   const router = useRouter();

--- a/src/component/Sidebar.jsx
+++ b/src/component/Sidebar.jsx
@@ -1,14 +1,14 @@
-import { useRouter } from "@tanstack/react-router";
+import { useRouter } from '@tanstack/react-router';
 
 export default function Sidebar() {
   const router = useRouter();
   const currentPath = router.state.location.pathname;
 
   const navItems = [
-    { label: "홈", to: "/", icon: "/icons/home-simple-door.svg" },
-    { label: "게시글 작성하기", to: "/write", icon: "/icons/text.svg" },
-    { label: "채팅", to: "/chat", icon: "/icons/Chat2.svg" },
-    { label: "마이 페이지", to: "/myprofile", icon: "/icons/user-circle.svg" },
+    { label: '홈', to: '/', icon: '/icons/home-simple-door.svg' },
+    { label: '게시글 작성하기', to: '/write', icon: '/icons/text.svg' },
+    { label: '채팅', to: '/chat', icon: '/icons/Chat2.svg' },
+    { label: '마이 페이지', to: '/myprofile', icon: '/icons/user-circle.svg' },
   ];
 
   return (
@@ -31,11 +31,7 @@ export default function Sidebar() {
             py-2.5 
             border-none 
             rounded-lg 
-            ${
-              currentPath === item.to
-                ? "bg-gray-200 text-gray-800"
-                : "bg-transparent text-blue-600"
-            } 
+            ${currentPath === item.to ? 'bg-gray-200 text-gray-800' : 'bg-transparent text-blue-600'} 
             font-medium 
             text-[15px] 
             mb-3 
@@ -63,13 +59,41 @@ export default function Sidebar() {
           mt-2
         "
         >
-          <li className="text-[15px]">전체</li>
-          <li className="text-[15px]">룸메</li>
-          <li className="text-[15px]">공동구매</li>
-          <li className="text-[15px]">프로젝트</li>
-          <li className="text-[15px]">공부</li>
-          <li className="text-[15px]">취미</li>
-          <li className="text-[15px]">배달</li>
+          <li>
+            <Link to="/" search={{ type: 'ALL' }} className="text-[15px]">
+              전체
+            </Link>
+          </li>
+          <li>
+            <Link to="/" search={{ type: 'ROOMMATE' }} className="text-[15px]">
+              룸메
+            </Link>
+          </li>
+          <li>
+            <Link to="/" search={{ type: 'DELIVERY' }} className="text-[15px]">
+              공동구매
+            </Link>
+          </li>
+          <li>
+            <Link to="/" search={{ type: 'PROJECT' }} className="text-[15px]">
+              프로젝트
+            </Link>
+          </li>
+          <li>
+            <Link to="/" search={{ type: 'STUDY' }} className="text-[15px]">
+              공부
+            </Link>
+          </li>
+          <li>
+            <Link to="/" search={{ type: 'HOBBY' }} className="text-[15px]">
+              취미
+            </Link>
+          </li>
+          <li>
+            <Link to="/" search={{ type: 'DELIVERY' }} className="text-[15px]">
+              배달
+            </Link>
+          </li>
         </ul>
       </div>
     </nav>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,7 +12,7 @@
 
 import { Route as rootRoute } from './routes/__root'
 import { Route as WriteImport } from './routes/write'
-import { Route as MyprofileImport } from './routes/myprofile'
+import { Route as MyProfileImport } from './routes/myProfile'
 import { Route as LoginImport } from './routes/login'
 import { Route as IndexImport } from './routes/index'
 
@@ -24,9 +24,9 @@ const WriteRoute = WriteImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
-const MyprofileRoute = MyprofileImport.update({
-  id: '/myprofile',
-  path: '/myprofile',
+const MyProfileRoute = MyProfileImport.update({
+  id: '/myProfile',
+  path: '/myProfile',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -60,11 +60,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginImport
       parentRoute: typeof rootRoute
     }
-    '/myprofile': {
-      id: '/myprofile'
-      path: '/myprofile'
-      fullPath: '/myprofile'
-      preLoaderRoute: typeof MyprofileImport
+    '/myProfile': {
+      id: '/myProfile'
+      path: '/myProfile'
+      fullPath: '/myProfile'
+      preLoaderRoute: typeof MyProfileImport
       parentRoute: typeof rootRoute
     }
     '/write': {
@@ -82,14 +82,14 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
-  '/myprofile': typeof MyprofileRoute
+  '/myProfile': typeof MyProfileRoute
   '/write': typeof WriteRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
-  '/myprofile': typeof MyprofileRoute
+  '/myProfile': typeof MyProfileRoute
   '/write': typeof WriteRoute
 }
 
@@ -97,30 +97,30 @@ export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
-  '/myprofile': typeof MyprofileRoute
+  '/myProfile': typeof MyProfileRoute
   '/write': typeof WriteRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/myprofile' | '/write'
+  fullPaths: '/' | '/login' | '/myProfile' | '/write'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/myprofile' | '/write'
-  id: '__root__' | '/' | '/login' | '/myprofile' | '/write'
+  to: '/' | '/login' | '/myProfile' | '/write'
+  id: '__root__' | '/' | '/login' | '/myProfile' | '/write'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
-  MyprofileRoute: typeof MyprofileRoute
+  MyProfileRoute: typeof MyProfileRoute
   WriteRoute: typeof WriteRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
-  MyprofileRoute: MyprofileRoute,
+  MyProfileRoute: MyProfileRoute,
   WriteRoute: WriteRoute,
 }
 
@@ -136,7 +136,7 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/login",
-        "/myprofile",
+        "/myProfile",
         "/write"
       ]
     },
@@ -146,8 +146,8 @@ export const routeTree = rootRoute
     "/login": {
       "filePath": "login.jsx"
     },
-    "/myprofile": {
-      "filePath": "myprofile.jsx"
+    "/myProfile": {
+      "filePath": "myProfile.jsx"
     },
     "/write": {
       "filePath": "write.jsx"

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,15 +1,17 @@
-import { createFileRoute } from "@tanstack/react-router";
-import Layout from "../component/Layout";
-import CardList from "../component/CardList";
+import { createFileRoute } from '@tanstack/react-router';
+import Layout from '../component/Layout';
+import CardList from '../component/CardList';
 
-export const Route = createFileRoute("/")({
+export const Route = createFileRoute('/')({
   component: RouteComponent,
+  validateSearch: (search) => ({ type: search.type ?? 'ALL' }),
 });
 
 function RouteComponent() {
+  const type = Route.useSearch().type;
   return (
     <Layout>
-      <CardList />
+      <CardList type={type} />
     </Layout>
   );
 }

--- a/src/routes/myprofile.jsx
+++ b/src/routes/myprofile.jsx
@@ -171,7 +171,7 @@ function MyProfileComponent() {
           >
             {user.posts.map((post) => (
               <div
-                key={post.id}
+                key={post.uuid}
                 className="
                   bg-white 
                   rounded-xl 

--- a/src/routes/myprofile.jsx
+++ b/src/routes/myprofile.jsx
@@ -1,46 +1,26 @@
-import { createFileRoute } from "@tanstack/react-router";
-import Layout from "../component/Layout";
+import { createFileRoute } from '@tanstack/react-router';
+import Layout from '../component/Layout';
+import { getUser } from '../api/user/getUSer';
+import React, { useEffect } from 'react';
 
-export const Route = createFileRoute("/myprofile")({
+export const Route = createFileRoute('/myProfile')({
   component: MyProfileComponent,
 });
 
 function MyProfileComponent() {
-  // 더미 데이터 추가
-  const dummyPosts = [
-    {
-      id: 1,
-      title: "긴급한 설명",
-      content: "간략한 설명",
-      type: "공동구매",
-      participants: new Array(3),
-      maxParticipants: 5,
-    },
-    {
-      id: 2,
-      title: "긴급한 설명",
-      content: "간략한 설명",
-      type: "공동구매",
-      participants: new Array(2),
-      maxParticipants: 5,
-    },
-    {
-      id: 3,
-      title: "긴급한 설명",
-      content: "간략한 설명",
-      type: "공동구매",
-      participants: new Array(4),
-      maxParticipants: 5,
-    },
-    {
-      id: 4,
-      title: "긴급한 설명",
-      content: "간략한 설명",
-      type: "공동구매",
-      participants: new Array(1),
-      maxParticipants: 5,
-    },
-  ];
+  const [user, setUser] = React.useState({
+    name: '',
+    studentId: '',
+    major: '',
+    email: '',
+    posts: [],
+  });
+
+  useEffect(() => {
+    getUser().then((data) => {
+      setUser(data);
+    });
+  }, []);
 
   return (
     <Layout>
@@ -109,7 +89,7 @@ function MyProfileComponent() {
                 mb-1
               "
             >
-              NAME
+              {user.name}
             </div>
             <div
               className="
@@ -117,7 +97,7 @@ function MyProfileComponent() {
                 font-normal
               "
             >
-              학번
+              {user.studentId}
             </div>
             <div
               className="
@@ -125,7 +105,7 @@ function MyProfileComponent() {
                 font-normal
               "
             >
-              학과
+              {user.major}
             </div>
             <div
               className="
@@ -133,7 +113,7 @@ function MyProfileComponent() {
                 font-normal
               "
             >
-              이메일
+              {user.email}
             </div>
           </div>
           {/* 좋아요(하트) */}
@@ -189,7 +169,7 @@ function MyProfileComponent() {
               gap-8
             "
           >
-            {dummyPosts.map((post) => (
+            {user.posts.map((post) => (
               <div
                 key={post.id}
                 className="

--- a/src/routes/myprofile.jsx
+++ b/src/routes/myprofile.jsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import Layout from '../component/Layout';
-import { getUser } from '../api/user/getUSer';
+import { getUser } from '../api/user/getUser';
 import React, { useEffect } from 'react';
 
 export const Route = createFileRoute('/myProfile')({

--- a/src/routes/myprofile.jsx
+++ b/src/routes/myprofile.jsx
@@ -212,7 +212,7 @@ function MyProfileComponent() {
                       mr-2
                     "
                   >
-                    #{post.type}
+                    #{post.postType}
                   </span>
                   <span
                     className="


### PR DESCRIPTION
1. 마이 페이지 추가
2. 기존에 게시물의 key prop이 map 함수에 iteration(반복이 몇번 수행되었는가)인 것을 게시물의 uuid(고유 식별 문자열)로 변경
![image](https://github.com/user-attachments/assets/de0a16e6-7aba-417b-b744-b6fc18b84512)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자 정보를 비동기적으로 불러와 마이프로필 페이지에 동적으로 표시합니다.
  - 게시글 유형별 필터링 기능이 추가되어 원하는 유형의 게시글만 볼 수 있습니다.
  - 사이드바 카테고리 메뉴가 클릭 가능한 링크로 변경되어 유형별 게시글 필터링이 가능합니다.

- **버그 수정**
  - 게시글 목록 렌더링 시 React key를 인덱스에서 고유 식별자(post.uuid)로 변경하여 안정성을 향상시켰습니다.

- **스타일**
  - 마이프로필 경로를 "/myprofile"에서 "/myProfile"로 변경하였습니다.
  - 게시글 속성명이 일부 변경되었습니다(post.type → post.postType 등).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->